### PR TITLE
add match ROLE to string

### DIFF
--- a/src/components/Topic/TopicUserInfo.jsx
+++ b/src/components/Topic/TopicUserInfo.jsx
@@ -5,6 +5,7 @@ import { formatDistanceToNow, parseISO } from 'date-fns';
 import ru from 'date-fns/locale/ru';
 import { StyledTopicUserInfo, UserInfoLeft } from './styled';
 import userProps from './propTypes/userProps';
+import { mapRoleToString } from '../../utils';
 
 const TopicUserInfo = ({ user }) => {
   return (
@@ -17,7 +18,7 @@ const TopicUserInfo = ({ user }) => {
       </UserInfoLeft>
       <Col>
         <p>
-          <Icon type="user" /> {user.role.role}
+          <Icon type="user" /> {mapRoleToString(user.role.role)}
         </p>
         <p>
           <Icon type="message" /> {user.messageCount}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -4,3 +4,13 @@ import ru from 'date-fns/locale/ru';
 // eslint-disable-next-line import/prefer-default-export
 export const dateToDateDistance = isoDate =>
   isoDate && formatDistance(parseISO(isoDate), new Date(), { locale: ru });
+
+export const mapRoleToString = role => {
+  const roles = {
+    ROLE_ADMIN: 'Администратор',
+    ROLE_MODERATOR: 'Модератор',
+    ROLE_USER: 'Пользователь',
+    ROLE_PROSPECT: 'Prospect',
+  };
+  return roles[role];
+};


### PR DESCRIPTION
На беке CommentDto.content.author.role.role возвращает ROLE_XXX.

На фронте добавил функцию матчинга в утилс:
const matchRoleToString = {
ROLE_ADMIN: 'Администратор',
ROLE_MODERATOR: 'Модератор',
ROLE_USER: 'Пользователь',
ROLE_PROSPECT: 'Prospect',
};