### PR TITLE
Fix comment editing

### DIFF
--- a/src/components/Profile/Messages.jsx
+++ b/src/components/Profile/Messages.jsx
@@ -22,7 +22,6 @@ class Messages extends React.Component {
   loadMessages = async () => {
     const { page: oldPage } = this.state;
     const newMessages = await queries.getProfileComments(oldPage);
-
     if (newMessages.length === 0) {
       return this.setState({ hasMore: false });
     }
@@ -31,6 +30,15 @@ class Messages extends React.Component {
       messages: [...messages, ...newMessages],
       page: page + 1,
     }));
+  };
+
+  updateMessages = updatedComment => {
+    this.setState(({ messages }) => {
+      const updatedComments = messages.map(mes =>
+        mes.commentId === updatedComment.commentId ? updatedComment : mes
+      );
+      return { messages: updatedComments };
+    });
   };
 
   render() {
@@ -46,7 +54,9 @@ class Messages extends React.Component {
 
     return (
       <TopicCommentsList
-        itemComponent={item => <TopicCommentItem comment={item} />}
+        itemComponent={item => (
+          <TopicCommentItem comment={item} updateComments={this.updateMessages} />
+        )}
         messages={messages}
         title=""
         fetchMessages={this.loadMessages}

--- a/src/components/Profile/Messages.jsx
+++ b/src/components/Profile/Messages.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Row } from 'antd';
+import { Row, message } from 'antd';
 
 import queries from '../../serverQueries';
 import TopicCommentsList from '../Topic/TopicCommentsList';
@@ -32,13 +32,28 @@ class Messages extends React.Component {
     }));
   };
 
-  updateMessages = updatedComment => {
+  handleUpdateMessage = updatedComment => {
     this.setState(({ messages }) => {
       const updatedComments = messages.map(mes =>
         mes.commentId === updatedComment.commentId ? updatedComment : mes
       );
       return { messages: updatedComments };
     });
+  };
+
+  handleDeleteMessage = commentId => {
+    queries
+      .deleteComment(commentId)
+      .then(() => {
+        this.setState(({ messages }) => {
+          const updatedComments = messages.filter(mes => mes.commentId !== commentId);
+          return { messages: updatedComments };
+        });
+        message.success('Сообщение удалено');
+      })
+      .catch(() => {
+        message.error('Похоже, что-то не так. Сообщение удалить не удалось.');
+      });
   };
 
   render() {
@@ -55,7 +70,11 @@ class Messages extends React.Component {
     return (
       <TopicCommentsList
         itemComponent={item => (
-          <TopicCommentItem comment={item} updateComments={this.updateMessages} />
+          <TopicCommentItem
+            comment={item}
+            updateComment={this.handleUpdateMessage}
+            deleteComment={this.handleDeleteMessage}
+          />
         )}
         messages={messages}
         title=""

--- a/src/components/Topic/TopicCommentItem.jsx
+++ b/src/components/Topic/TopicCommentItem.jsx
@@ -55,7 +55,7 @@ class TopicCommentItem extends React.Component {
       deleteComment,
       getTopics,
       page,
-      updateComments,
+      updateComment,
     } = this.props;
     const { withActions, toggleEdeting } = this.state;
     const { isLogin } = this.context;
@@ -107,7 +107,7 @@ class TopicCommentItem extends React.Component {
         idUser={comment.author.id}
         commentId={comment.commentId}
         getTopics={getTopics}
-        updateComments={updateComments}
+        updateComment={updateComment}
         page={page}
       />
     );
@@ -163,13 +163,13 @@ TopicCommentItem.propTypes = {
   deleteComment: PropTypes.func,
   getTopics: PropTypes.func.isRequired,
   page: PropTypes.number.isRequired,
-  updateComments: PropTypes.func,
+  updateComment: PropTypes.func,
 };
 
 TopicCommentItem.defaultProps = {
   handleQuoteComment: () => {},
   deleteComment: () => {},
-  updateComments: undefined,
+  updateComment: undefined,
 };
 
 export default TopicCommentItem;

--- a/src/components/Topic/TopicCommentItem.jsx
+++ b/src/components/Topic/TopicCommentItem.jsx
@@ -49,7 +49,14 @@ class TopicCommentItem extends React.Component {
   }
 
   render() {
-    const { comment, handleQuoteComment, deleteComment, getTopics, page } = this.props;
+    const {
+      comment,
+      handleQuoteComment,
+      deleteComment,
+      getTopics,
+      page,
+      updateComments,
+    } = this.props;
     const { withActions, toggleEdeting } = this.state;
     const { isLogin } = this.context;
     const convertedImages = comment.photos.map(photo => {
@@ -100,6 +107,7 @@ class TopicCommentItem extends React.Component {
         idUser={comment.author.id}
         commentId={comment.commentId}
         getTopics={getTopics}
+        updateComments={updateComments}
         page={page}
       />
     );
@@ -155,11 +163,13 @@ TopicCommentItem.propTypes = {
   deleteComment: PropTypes.func,
   getTopics: PropTypes.func.isRequired,
   page: PropTypes.number.isRequired,
+  updateComments: PropTypes.func,
 };
 
 TopicCommentItem.defaultProps = {
   handleQuoteComment: () => {},
   deleteComment: () => {},
+  updateComments: undefined,
 };
 
 export default TopicCommentItem;

--- a/src/components/Topic/TopicEditingForm.jsx
+++ b/src/components/Topic/TopicEditingForm.jsx
@@ -31,7 +31,16 @@ class TopicEditingForm extends React.Component {
   };
 
   handleSubmitForm = text => {
-    const { idTopic, idUser, commentId, getTopics, page, history, handleCancel } = this.props;
+    const {
+      idTopic,
+      idUser,
+      commentId,
+      getTopics,
+      page,
+      history,
+      handleCancel,
+      updateComments,
+    } = this.props;
 
     if (!commentId) {
       message.error('Вы не выбрали какой комментарий редактировать!');
@@ -53,9 +62,14 @@ class TopicEditingForm extends React.Component {
     });
     queries
       .updateComment(editingComment)
-      .then(() => {
+      .then(comment => {
         history.push(`${history.location.pathname}?page=${page}`);
-        getTopics(page);
+        if (getTopics) {
+          getTopics(page);
+        }
+        if (updateComments) {
+          updateComments(comment);
+        }
         message.success('Сообщение сохранено');
         handleCancel();
       })
@@ -130,6 +144,9 @@ export default withRouter(TopicEditingForm);
 
 TopicEditingForm.defaultProps = {
   commentId: null,
+  updateComments: undefined,
+  getTopics: undefined,
+  page: undefined,
 };
 
 TopicEditingForm.propTypes = {
@@ -139,8 +156,9 @@ TopicEditingForm.propTypes = {
   idTopic: PropTypes.number.isRequired,
   idUser: PropTypes.number.isRequired,
   commentId: PropTypes.number,
-  getTopics: PropTypes.func.isRequired,
-  page: PropTypes.number.isRequired,
+  getTopics: PropTypes.func,
+  page: PropTypes.number,
+  updateComments: PropTypes.func,
   history: PropTypes.shape({
     push: PropTypes.func,
     location: PropTypes.shape({

--- a/src/components/Topic/TopicEditingForm.jsx
+++ b/src/components/Topic/TopicEditingForm.jsx
@@ -39,7 +39,7 @@ class TopicEditingForm extends React.Component {
       page,
       history,
       handleCancel,
-      updateComments,
+      updateComment,
     } = this.props;
 
     if (!commentId) {
@@ -67,8 +67,8 @@ class TopicEditingForm extends React.Component {
         if (getTopics) {
           getTopics(page);
         }
-        if (updateComments) {
-          updateComments(comment);
+        if (updateComment) {
+          updateComment(comment);
         }
         message.success('Сообщение сохранено');
         handleCancel();
@@ -144,7 +144,7 @@ export default withRouter(TopicEditingForm);
 
 TopicEditingForm.defaultProps = {
   commentId: null,
-  updateComments: undefined,
+  updateComment: undefined,
   getTopics: undefined,
   page: undefined,
 };
@@ -158,7 +158,7 @@ TopicEditingForm.propTypes = {
   commentId: PropTypes.number,
   getTopics: PropTypes.func,
   page: PropTypes.number,
-  updateComments: PropTypes.func,
+  updateComment: PropTypes.func,
   history: PropTypes.shape({
     push: PropTypes.func,
     location: PropTypes.shape({

--- a/src/serverQueries/index.jsx
+++ b/src/serverQueries/index.jsx
@@ -168,9 +168,11 @@ class Queries {
       formData.set('image2', editingComment.image2.originFileObj, editingComment.image2.name);
     }
 
-    const res = await axios.put('/api/comment/update', formData, { params: { commentId } });
+    const res = await axios.put('/api/comment/update', formData, {
+      params: { commentID: commentId },
+    });
 
-    return res.status;
+    return res.data;
   };
 
   deleteComment = async commentId => {


### PR DESCRIPTION
исправлено редактирование и удаление. Сообщения ( по факту коменты ) загружаются из /api/comments/ и хранятся в локальном стейте. Для апдейта коментов пробросил в TopicCommentItem хендлеры handleUpdateMessage и handleDeleteMessage, которые модифицируют локальный стейт.
В TopicEditingForm в handleSubmitForm происходит переход
history.push(${history.location.pathname}?page=${page})
Я не знаю зачем нужен параметр page. Предлагаю его убрать.