### PR TITLE
fix article-delete-coment

### DIFF
--- a/src/components/Articles/ArticleComment.jsx
+++ b/src/components/Articles/ArticleComment.jsx
@@ -19,7 +19,15 @@ const ArticleComment = props => {
     onDeleteComment,
   } = props;
 
-  const { id: commentId, commentText: text, commentDateTime: date, author, nested } = comment;
+  const {
+    id: commentId,
+    parentId,
+    commentText: text,
+    commentDateTime: date,
+    author,
+    nested,
+    deleted,
+  } = comment;
   const { user } = useContext(Context);
 
   const actionsArr = [];
@@ -55,8 +63,8 @@ const ArticleComment = props => {
         key="delete"
         role="button"
         tabIndex="0"
-        onKeyPress={onDeleteComment(commentId)}
-        onClick={onDeleteComment(commentId)}
+        onKeyPress={onDeleteComment(commentId, parentId)}
+        onClick={onDeleteComment(commentId, parentId)}
       >
         Удалить
       </span>
@@ -76,7 +84,7 @@ const ArticleComment = props => {
 
   return (
     <Comment
-      actions={actionsArr}
+      actions={deleted ? null : actionsArr}
       author={author.nickName}
       datetime={
         <Tooltip
@@ -118,6 +126,8 @@ ArticleComment.propTypes = {
     author: PropTypes.object.isRequired,
     commentDateTime: PropTypes.string,
     commentText: PropTypes.string,
+    deleted: PropTypes.bool,
+    parentId: PropTypes.number,
   }).isRequired,
   // eslint-disable-next-line react/require-default-props
   commentWithOpenEditor: PropTypes.number,


### PR DESCRIPTION
Улучшен функционла удаления коментариев к статьям
Если коментарий удален а у него есть подкоментарии он остается но текст становится "Коментарий удален"  закрывается окно редактирования этого коментария
Пример 
Коментарий 1 
  Текст подкоментария 
удаляем Коментарий 1 становится 
Коментрий был удален
   Текс подкоментария
P.S. на беке работает с анамолией (если удалить подкоментарий у удаленного он придет с сервера)