### PR TITLE
Fix invite redirect

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -66,16 +66,16 @@ class App extends React.Component {
         <Header />
         <CommonRoute />
         <AuthRoute isLogin={isLogin} />
-        <PrivateRoute isLogin={isLogin} path="/profile" component={Profile} />
+        <PrivateRoute isAllowed={isLogin} path="/profile" component={Profile} />
         <PrivateRoute
-          isLogin={isLogin && role === 'ROLE_ADMIN'}
+          isAllowed={isLogin && role === 'ROLE_ADMIN'}
           path="/admin-panel"
           component={AdminPanel}
         />
         <TopicRoute />
         <SubsectionRoute />
         <SearchRoute />
-        <ArticlesRoute isLogin={isLogin} />
+        <ArticlesRoute isLogin={isLogin} role={role} />
         {/* TODO delete eslint disable */}
         {/* eslint-disable-next-line no-undef */}
         <ChatRoute path="/chat" isLogin={isLogin} user={user} component={ChatAuth} />

--- a/src/routes/ArticlesRoute.jsx
+++ b/src/routes/ArticlesRoute.jsx
@@ -1,39 +1,48 @@
 import React from 'react';
-import { Redirect, Route, Switch } from 'react-router-dom';
+import { Switch } from 'react-router-dom';
 import PropTypes from 'prop-types';
+import { userRoles } from '../constants';
 import Articles from '../components/Articles/Articles';
 import ArticleCreate from '../components/Articles/ArticleCreate';
-import AdminRoute from './AdminRoute';
+import PrivateRoute from './PrivateRoute';
 import ArticleUpdate from '../components/Articles/ArticleUpdate';
 import ArticlePage from '../components/Articles/ArticlePage';
 
-const ArticlesRoute = ({ isLogin }) => {
+const ArticlesRoute = ({ isLogin, role }) => {
   return (
     <>
-      <Route>
-        {isLogin ? (
-          <Switch>
-            <Route exact path="/articles">
-              <Articles />
-            </Route>
-            <AdminRoute exact path="/article/create">
-              <ArticleCreate />
-            </AdminRoute>
-            <Route exact path="/article/:articleId" component={ArticlePage} />
-            <AdminRoute exact path="/article/:articleId/update">
-              <ArticleUpdate />
-            </AdminRoute>
-          </Switch>
-        ) : (
-          <Redirect to="/login" />
-        )}
-      </Route>
+      <Switch>
+        <PrivateRoute isAllowed={isLogin} exact path="/articles" component={Articles} />
+        <PrivateRoute
+          isAllowed={isLogin && role === userRoles.admin}
+          exact
+          path="/article/create"
+          component={ArticleCreate}
+        />
+        <PrivateRoute
+          isAllowed={isLogin}
+          exact
+          path="/article/:articleId"
+          component={ArticlePage}
+        />
+        <PrivateRoute
+          isAllowed={isLogin && role === userRoles.admin}
+          exact
+          path="/article/:articleId/update"
+          component={ArticleUpdate}
+        />
+      </Switch>
     </>
   );
 };
 
 ArticlesRoute.propTypes = {
   isLogin: PropTypes.bool.isRequired,
+  role: PropTypes.string,
+};
+
+ArticlesRoute.defaultProps = {
+  role: null,
 };
 
 export default ArticlesRoute;

--- a/src/routes/AuthRoute.jsx
+++ b/src/routes/AuthRoute.jsx
@@ -9,7 +9,9 @@ import RegistrationAccept from '../components/RegistrationAccept';
 const AuthRoute = ({ isLogin }) => {
   return (
     <>
-      <Route path="/invite">{isLogin ? <Redirect to="/" /> : <Registration />}</Route>
+      <Route path="/invite">
+        <Registration />
+      </Route>
       <Route path="/registration-accept" component={RegistrationAccept} />
       <Route path="/login">{isLogin ? <Redirect to="/" /> : <Login />}</Route>
     </>

--- a/src/routes/AuthRoute.jsx
+++ b/src/routes/AuthRoute.jsx
@@ -9,9 +9,7 @@ import RegistrationAccept from '../components/RegistrationAccept';
 const AuthRoute = ({ isLogin }) => {
   return (
     <>
-      <Route path="/invite">
-        <Registration />
-      </Route>
+      <Route path="/invite">{isLogin ? <Redirect to="/" /> : <Registration />}</Route>
       <Route path="/registration-accept" component={RegistrationAccept} />
       <Route path="/login">{isLogin ? <Redirect to="/" /> : <Login />}</Route>
     </>

--- a/src/routes/PrivateRoute.jsx
+++ b/src/routes/PrivateRoute.jsx
@@ -2,12 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Route, Redirect } from 'react-router-dom';
 
-const PrivateRoute = ({ isLogin, component: Component, ...rest }) => (
-  <Route {...rest}>{isLogin ? <Component /> : <Redirect to="/" />}</Route>
+const PrivateRoute = ({ isAllowed, component: Component, ...rest }) => (
+  <Route {...rest}>{isAllowed ? <Component /> : <Redirect to="/" />}</Route>
 );
 
 PrivateRoute.propTypes = {
-  isLogin: PropTypes.bool.isRequired,
+  isAllowed: PropTypes.bool.isRequired,
   path: PropTypes.string.isRequired,
   component: PropTypes.elementType.isRequired,
 };


### PR DESCRIPTION
Проблема редиректа на регистрацию с /invite была в ArticlesRoute. Переделал PrivateRoute что бы он принимал isAllowed вместо isLogin.  Теперь можно редиректить на главную, если юзер пытается перейти на PrivateRoute, но у него нет прав.