### PR TITLE
fix article show

### DIFF
--- a/src/components/Articles/ArticlePage.jsx
+++ b/src/components/Articles/ArticlePage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { withRouter } from 'react-router-dom';
 import { Spin } from 'antd';
 import Context from '../Context';
 import Article from './Article';
@@ -250,4 +251,4 @@ ArticlePage.propTypes = {};
 
 ArticlePage.defaultProps = {};
 
-export default ArticlePage;
+export default withRouter(ArticlePage);


### PR DESCRIPTION
Предыдущий комиит [ad4cc55](https://github.com/StalnoyKapibar/oldranger-front/commit/ad4cc558695fa4ac69a29c4d3044f410e4ab20f3) изменил работу роутинга статей - в результате сломалось отображение одиночной статьи(в компоненте предусмотрено получение в пропсы объекта match)
Починка - обертка компонента в withRouter 